### PR TITLE
build: change sponsorship data URL to manageable URL

### DIFF
--- a/web-components/ddev/sponsors-banner/sponsors-banner.js
+++ b/web-components/ddev/sponsors-banner/sponsors-banner.js
@@ -5,7 +5,7 @@ class DdevSponsorsBanner extends HTMLElement {
   }
 
   connectedCallback() {
-    fetch("https://raw.githubusercontent.com/ddev/sponsorship-data/refs/heads/main/data/all-sponsorships.json")
+    fetch("https://ddev.com/s/sponsorship-data.json")
       .then((response) => response.json())
       .then((json) => {
         const goal = json.current_goal?.target_amount || 12000;


### PR DESCRIPTION
Thanks for maintaining this!

This PR changes the sponsorship data URL to one that we can redirect as things change in the future. 

Please test and make sure you like it, but it should work fine.

https://ddev.com/s/sponsorship-data.json